### PR TITLE
fix: 修复 description 只在创建时写入、后续 publish 不更新的 bug

### DIFF
--- a/src/utils/publish-skill.js
+++ b/src/utils/publish-skill.js
@@ -52,6 +52,9 @@ function publishSkillFromZip({ user, skillId, name, description, changelog, visi
       ).run(skill_id, user.id, 'owner', user.id);
     });
     createSkillTx();
+  } else if (description) {
+    // Update description for existing skills
+    SkillModel.update(skill_id, undefined, description, undefined, undefined);
   }
 
   const version = generateVersionNumber();


### PR DESCRIPTION
  ## 问题

  `publishSkillFromZip()` 只在新建 skill 时（`!skillExists` 分支）调用 `SkillModel.create()` 写入 `description`。当 skill      
  已存在时，CLI 发送的 `description` 字段被忽略，只进了 `versions` 表，`skills.description` 始终保持初始值。

  ## 修复

  在 `skillExists` 为 true 且 `description` 非空时，调用 `SkillModel.update()` 刷新 `skills.description`。

  ## 改动                                                                                                                      ────────────────────────

  src/utils/publish-skill.js — 加 3 行                                                                                         ────────────────────────

  ## 复现

  1. 创建一个 skill（description = "5 步检查"）
  2. 修改 SKILL.md description 为 "7 步检查"，`skb publish`
  3. 访问 `GET /api/v1/skills/<id>` → description 仍为 "5 步检查"