### PR TITLE
fix(cappy): only start mascot when stdout is a TTY

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -194,8 +194,9 @@ async function start() {
     const PORT = process.env.PORT || 8000;
     const HOST = process.env.HOST || '0.0.0.0';
     
-    // Cappy off unless ENABLE_CAPPY=true
-    const enableCappy = process.env.ENABLE_CAPPY === 'true';
+    // Cappy on only when ENABLE_CAPPY=true AND stdout is a TTY
+    // (avoids banner-animation spamming pm2/systemd logs at ~5MB/min)
+    const enableCappy = process.env.ENABLE_CAPPY === 'true' && !!process.stdout.isTTY;
     let cappy = null;
 
     if (enableCappy) {


### PR DESCRIPTION
When skill-base runs under pm2/systemd (non-TTY), the Cappy banner animation writes ANSI escape frames to stdout at ~5MB/min, producing 5GB+ log files within hours. The existing env gate (ENABLE_CAPPY === "true") does not help because bin/skill-base.js sets ENABLE_CAPPY=true by default, so the mascot starts unconditionally.

Add a TTY check on top of the env gate:
- TTY + ENABLE_CAPPY=true  -> mascot on  (terminal users, unchanged)
- non-TTY (pm2/systemd)    -> mascot off (no log spam)
- ENABLE_CAPPY != "true"   -> mascot off (unchanged)

Verified on deployment: 30min Cappy run wrote 5163MB to pm2 out.log; after this fix (combined with --no-cappy CLI flag for belt-and-suspenders), 60s idle produced 0 bytes of output.