### PR TITLE
fix(cappy): 非 TTY 环境下禁用吉祥物动画，防 pm2/systemd 日志爆炸

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -194,8 +194,9 @@ async function start() {
     const PORT = process.env.PORT || 8000;
     const HOST = process.env.HOST || '0.0.0.0';
     
-    // Cappy off unless ENABLE_CAPPY=true
-    const enableCappy = process.env.ENABLE_CAPPY === 'true';
+    // Cappy on only when ENABLE_CAPPY=true AND stdout is a TTY
+    // (avoids banner-animation spamming pm2/systemd logs at ~5MB/min)
+    const enableCappy = process.env.ENABLE_CAPPY === 'true' && !!process.stdout.isTTY;
     let cappy = null;
 
     if (enableCappy) {


### PR DESCRIPTION
  ## 问题

  skill-base 用 `setInterval(tick, 180-340ms)` 持续向 stdout 写 ANSI 动画帧。pm2/systemd/docker 等非 TTY 环境下，stdout
  被重定向到日志文件，动画帧持续累积。

  **实测**：生产环境（pm2 启动漏 `--no-cappy`），日志文件存在 44 天累积 **5163 MB**（基于文件 Birth time 实测）。

  ## 现有开关的不足

  `ENABLE_CAPPY === 'true'` 这个 env 开关本身有效，但默认值对非交互环境不友好：

  - `bin/skill-base.js` 默认 `enableCappy = true` → env 设为 true → cappy 启动
  - 只有 `--daemon` 模式 bin 才自动给 child 加 `--no-cappy`（line 247-250）
  - **普通模式不自动加**——用户必须显式传 `--no-cappy`，否则 cappy 启动

  ## 常见运维陷阱

  ```bash
  # 漏 --no-cappy → cappy 启动 → 日志默默累积
  pm2 start npx --name skill-base -- -y skill-base -d /www/skill-data -p 8000

  # 必须显式加上
  pm2 start npx --name skill-base -- -y skill-base -d /www/skill-data -p 8000 --no-cappy

  --no-cappy 在文档里不显眼，pm2/systemd 用户容易漏掉，几天到几周后日志膨胀才被发现。

  修复方案

  在 src/index.js 的 env 判断之上加 TTY 检测，作为默认安全兜底：

  // Before
  const enableCappy = process.env.ENABLE_CAPPY === 'true';

  // After
  const enableCappy = process.env.ENABLE_CAPPY === 'true' && !!process.stdout.isTTY;

  非 TTY 环境（pm2/systemd/docker/CI）下 cappy 自动关闭；终端用户不受影响。

  行为矩阵

  ┌────────────────────────────────┬─────────────────────┬──────────────┬──────────────────────┐
  │              场景              │    ENABLE_CAPPY     │ stdout.isTTY │        cappy         │
  ├────────────────────────────────┼─────────────────────┼──────────────┼──────────────────────┤
  │ 终端 npx skill-base            │ true（默认）        │ true         │ ✅ 开                │
  ├────────────────────────────────┼─────────────────────┼──────────────┼──────────────────────┤
  │ pm2/systemd（忘加 --no-cappy） │ true（默认）        │ false        │ ❌ 关 ← 新行为，兜底 │
  ├────────────────────────────────┼─────────────────────┼──────────────┼──────────────────────┤
  │ pm2/systemd（带 --no-cappy）   │ false               │ false        │ ❌ 关                │
  ├────────────────────────────────┼─────────────────────┼──────────────┼──────────────────────┤
  │ --daemon child                 │ false（bin 自动加） │ false        │ ❌ 关                │
  ├────────────────────────────────┼─────────────────────┼──────────────┼──────────────────────┤
  │ ENABLE_CAPPY=false env         │ false               │ 任意         │ ❌ 关                │
  └────────────────────────────────┴─────────────────────┴──────────────┴──────────────────────┘

  实测

  - 生产环境（pm2 漏 --no-cappy）：日志文件存在 44 天累积 5163 MB（文件 Birth time 实测）
  - 加 TTY gate + 重启后：日志文件保持 0 字节，未再增长
  - API /api/v1/health 行为不变

  备注

  - 最小改动（加 3 行、改 2 行）
  - 不改 bin 默认值，向后兼容
  - 终端用户体验无变化
  - 提交：8454c64 on fix/cappy-non-tty-gate（已 fast-forward merge 到 fork main）